### PR TITLE
plus_code feature added to type definition file

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -302,6 +302,11 @@ interface Geometry {
   };
 }
 
+interface PlusCode {
+  compound_code: string;
+  global_code: string;
+}
+
 interface GooglePlaceDetail {
   address_components: AddressComponent[];
   adr_address: string;
@@ -311,6 +316,7 @@ interface GooglePlaceDetail {
   id: string;
   name: string;
   place_id: string;
+  plus_code: PlusCode;
   reference: string;
   scope: 'GOOGLE';
   types: PlaceType;

--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -413,7 +413,7 @@ interface GooglePlacesAutocompleteProps {
   renderLeftButton?: () => JSX.Element | React.ComponentType<{}>;
   renderRightButton?: () => JSX.Element | React.ComponentType<{}>;
   renderRow?: (data: GooglePlaceData) => JSX.Element | React.ComponentType<{}>;
-  
+
   // sets the request URL to something other than the google api.  Helpful if you want web support or to use your own api.
   requestUrl?: RequestUrl;
   styles?: Partial<Styles> | Object;


### PR DESCRIPTION
Hello,

I have added the missing the typings for plus_code which is recently introduced.

https://cloud.google.com/blog/products/maps-platform/introducing-plus-codes-place-autocomplete-place-details-and-geocoding-help-you-serve-users-everywhere